### PR TITLE
Add ec2 support

### DIFF
--- a/agent-scheduler/src/handlers/buildkite-run-task.js
+++ b/agent-scheduler/src/handlers/buildkite-run-task.js
@@ -109,6 +109,16 @@ function atLeastCpuMemory(requestedCpu, requestedMemory) {
 async function getEcsRunTaskParamsForJob(cluster, job) {
     let taskParams = getDefaultEcsRunTaskParams(cluster, job);
 
+    let launchType = getAgentQueryRule("launch-type", job.agent_query_rules);
+    if (launchType != undefined) {
+        if (launchType == "fargate") {
+            // nop, fargate is default
+        } else if (launchType == "ec2") {
+            taskParams.launchType = "EC2";
+            delete taskParams.networkConfiguration.awsvpcConfiguration.assignPublicIp;
+        }
+    }
+
     let taskDefinition = getAgentQueryRule("task-definition", job.agent_query_rules);
     if (taskDefinition != undefined) {
         // Task definition is overridden...

--- a/agent-scheduler/src/handlers/buildkite-run-task.js
+++ b/agent-scheduler/src/handlers/buildkite-run-task.js
@@ -15,16 +15,35 @@ function getAgentQueryRule(rule, agentQueryRules) {
 function getDefaultEcsRunTaskParams(cluster, job) {
     let jobId = job.uuid || job.id;
     let subnets = process.env.VPC_SUBNETS.split(",");
+
+    let vpcConfiguration;
+    let launchType = process.env.LAUNCH_TYPE;
+    switch (launchType) {
+        case "FARGATE":
+            // Scheduled in a public or private subnet with a 0.0.0.0/0 gateway
+            // route.
+            vpcConfiguration = {
+                assignPublicIp: "ENABLED",
+                subnets: subnets,
+            };
+            break;
+        case "EC2":
+            // Scheduled in a private subnet with a 0.0.0.0/0 NAT gateway route.
+            vpcConfiguration = {
+                subnets: subnets,
+            };
+            break;
+        default:
+            throw `unsupported LAUNCH_TYPE environment variable: ${launchType}`;
+            break;
+    }
     
     let params = {
         cluster: cluster,
         count: 1,
-        launchType: "FARGATE",
+        launchType: launchType,
         networkConfiguration: {
-            awsvpcConfiguration: {
-                assignPublicIp: "ENABLED",
-                subnets: subnets
-            }
+            awsvpcConfiguration: vpcConfiguration,
         },
         overrides: {
             containerOverrides: [
@@ -108,18 +127,6 @@ function atLeastCpuMemory(requestedCpu, requestedMemory) {
 
 async function getEcsRunTaskParamsForJob(cluster, job) {
     let taskParams = getDefaultEcsRunTaskParams(cluster, job);
-
-    let launchType = getAgentQueryRule("launch-type", job.agent_query_rules);
-    if (launchType != undefined) {
-        console.log(`fn=getEcsRunTaskParamsForJob launchType=${launchType}`);
-
-        if (launchType == "fargate") {
-            // nop, fargate is default
-        } else if (launchType == "ec2") {
-            taskParams.launchType = "EC2";
-            delete taskParams.networkConfiguration.awsvpcConfiguration.assignPublicIp;
-        }
-    }
 
     let taskDefinition = getAgentQueryRule("task-definition", job.agent_query_rules);
     if (taskDefinition != undefined) {

--- a/agent-scheduler/src/handlers/buildkite-run-task.js
+++ b/agent-scheduler/src/handlers/buildkite-run-task.js
@@ -111,6 +111,8 @@ async function getEcsRunTaskParamsForJob(cluster, job) {
 
     let launchType = getAgentQueryRule("launch-type", job.agent_query_rules);
     if (launchType != undefined) {
+        console.log(`fn=getEcsRunTaskParamsForJob launchType=${launchType}`);
+
         if (launchType == "fargate") {
             // nop, fargate is default
         } else if (launchType == "ec2") {

--- a/agent-scheduler/template.yml
+++ b/agent-scheduler/template.yml
@@ -44,6 +44,13 @@ Parameters:
   EcsClusterName:
     Type: String
     Description: Name of the ECS Cluster to schedule task definitions in.
+  EcsLaunchType:
+    Type: String
+    Description: How to launch the task definition containers.
+    AllowedValues:
+      - FARGATE
+      - EC2
+    Default: FARGATE
   SshAgentBackend:
     Type: String
     Default: ''
@@ -129,6 +136,7 @@ Resources:
         Variables:
           ECS_CLUSTER_NAME: !Ref EcsClusterName
           VPC_SUBNETS: !Join [ ',', !Ref VpcSubnetIds ]
+          LAUNCH_TYPE: !Ref EcsLaunchType
           TASK_ROLE_ARN_PREFIX: !Sub "arn:aws:iam::${AWS::AccountId}:role/BuildkiteAgentTask"
           DEFAULT_EXECUTION_ROLE_ARN: !GetAtt DefaultExecutionRole.Arn
           BUILDKITE_AGENT_TOKEN_PARAMETER_PATH: !Ref BuildkiteAgentTokenParameterPath


### PR DESCRIPTION
Adds a `launch-type` agent query rule which can be `"fargate"` or `"ec2"`.

Agent scheduler needs to know about the given network topology and the backend. If fargate give the tasks a public ip. This should just work even if they’re in a private subnet with no internet gateway access so long as the route table says go via a nat gateway 🤔 If ec2 the subnet must have access to a nat gateway and agent scheduler must not specify `taskParams.networkConfiguration.awsvpcConfiguration.assignPublicIp` otherwise ecs:RunTask returns an error.

To decide:

- [ ] Is this a useful agent query rule, do we want to address a different compute backend inside the same Buildkite Queue? Should a given deployment of agent scheduler be configured for network topology and backend (fargate / ec2) up front at CloudFormation deploy time?

Depends on https://github.com/keithduncan/buildkite-on-demand-template/pull/1